### PR TITLE
feat: Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,15 +8,15 @@ edition = "2021"
 
 [dependencies]
 #tui = "0.18.0"
-ratatui = "0.20.0"
+ratatui = "0.28.1"
 bounded-vec-deque = { version = "0.1.1", optional = true }
-lazy_static = { version = "1.4.0", optional = true }
-time = { version = "0.3.11", features = ["local-offset", "macros"] , optional = true }
+lazy_static = { version = "1.5.0", optional = true }
+time = { version = "0.3.36", features = ["local-offset", "macros"] , optional = true }
 serde = { version ="1.0", optional = true }
 serde_derive = { version = "1.0", optional = true }
 
 [dev-dependencies]
-crossterm = "0.23.2"
+crossterm = "0.28.1"
 
 [features]
 default = ["styled_list", "calendar", "text_macros"]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Additional widgets for [ratatui](https://crates.io/crates/ratatui).
 
-These widgets are designed to operate similar to the built-in widgets in tui-rs, and should fit
+These widgets are designed to operate similar to the built-in widgets in ratatui, and should fit
 into your app cleanly.
 
 TODO: Add example gifs
@@ -19,15 +19,15 @@ Since the internals are documented as well.
 By default all the widgets are built and available:
 ```toml
 [dependencies]
-extra-widgets = "0.0.1"
-ratatui = "0.20.0"
+extra-widgets = "0.1.0"
+ratatui = "0.28.1"
 ```
 Alternately, each widget can be enabled individually. The feature names are the same as the
 module name for the widget. To just use the calendar widget:
 ```toml
 [dependencies]
-extra-widgets = {"0.0.1" default-features = false, features = ["calendar"] }
-ratatui = "0.20.0"
+extra-widgets = {"0.1.0" default-features = false, features = ["calendar"] }
+ratatui = "0.28.1"
 ```
 Dependencies for each widget are only pulled if the feature is enabled.
 

--- a/examples/calendar/main.rs
+++ b/examples/calendar/main.rs
@@ -7,7 +7,7 @@ use crossterm::{
 };
 
 use ratatui::{
-    backend::{Backend, CrosstermBackend},
+    backend::CrosstermBackend,
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     Frame, Terminal,
@@ -44,8 +44,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-fn draw<B: Backend>(f: &mut Frame<B>) {
-    let app_area = f.size();
+fn draw(f: &mut Frame) {
+    let app_area = f.area();
 
     let calarea = Rect {
         x: app_area.x + 1,

--- a/examples/list_demo/demos/basic.rs
+++ b/examples/list_demo/demos/basic.rs
@@ -1,5 +1,4 @@
 use ratatui::{
-    backend::Backend,
     layout::Rect,
     style::{Color, Style},
     Frame,
@@ -9,7 +8,7 @@ use extra_widgets::styled_list::{ItemDisplay, StyledList};
 
 use super::super::{words, AppState};
 
-pub fn basic<B: Backend>(area: Rect, state: &mut AppState, f: &mut Frame<B>) {
+pub fn basic(area: Rect, state: &mut AppState, f: &mut Frame) {
     let demo_items = words();
     let demo_list = StyledList::new(demo_items)
         .default_style(Style::reset().bg(Color::Black).fg(Color::White))

--- a/examples/list_demo/demos/fixed.rs
+++ b/examples/list_demo/demos/fixed.rs
@@ -1,5 +1,4 @@
 use ratatui::{
-    backend::Backend,
     layout::Rect,
     style::{Color, Style},
     Frame,
@@ -9,7 +8,7 @@ use extra_widgets::styled_list::{ItemDisplay, StyledList, WindowType};
 
 use super::super::{words, AppState};
 
-pub fn fixed<B: Backend>(area: Rect, state: &mut AppState, f: &mut Frame<B>) {
+pub fn fixed(area: Rect, state: &mut AppState, f: &mut Frame) {
     let demo_items = words();
     let demo_list = StyledList::new(demo_items)
         .default_style(Style::reset().bg(Color::Black).fg(Color::White))

--- a/examples/list_demo/demos/separated.rs
+++ b/examples/list_demo/demos/separated.rs
@@ -1,5 +1,4 @@
 use ratatui::{
-    backend::Backend,
     layout::Rect,
     style::{Color, Style},
     Frame,
@@ -9,7 +8,7 @@ use extra_widgets::styled_list::{ItemDisplay, StyledList};
 
 use super::super::{words, AppState};
 
-pub fn separated<B: Backend>(area: Rect, state: &mut AppState, f: &mut Frame<B>) {
+pub fn separated(area: Rect, state: &mut AppState, f: &mut Frame) {
     let demo_items = words();
     let demo_list = StyledList::new(demo_items)
         .default_style(Style::reset().bg(Color::Black).fg(Color::White))

--- a/examples/list_demo/demos/styled_items.rs
+++ b/examples/list_demo/demos/styled_items.rs
@@ -1,5 +1,4 @@
 use ratatui::{
-    backend::Backend,
     layout::Rect,
     style::{Color, Modifier, Style},
     Frame,
@@ -9,7 +8,7 @@ use extra_widgets::styled_list::{Indicator, ItemDisplay, LineIndicators, StyledL
 
 use super::super::{words, AppState};
 
-pub fn styled_items<B: Backend>(area: Rect, state: &mut AppState, f: &mut Frame<B>) {
+pub fn styled_items(area: Rect, state: &mut AppState, f: &mut Frame) {
     let demo_items = words();
     let orange = Style::default().bg(Color::Rgb(242, 147, 5));
     let demo_items =

--- a/examples/macros/main.rs
+++ b/examples/macros/main.rs
@@ -7,7 +7,7 @@ use crossterm::{
 };
 
 use ratatui::{
-    backend::{Backend, CrosstermBackend},
+    backend::CrosstermBackend,
     layout::{Constraint, Direction, Layout, Margin, Rect},
     style::Color,
     text::Text,
@@ -44,7 +44,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-fn draw<B: Backend>(f: &mut Frame<B>) {
+fn draw(f: &mut Frame) {
     let result = text! {
         underlined!("Some fancy text for you!");
         "";
@@ -90,7 +90,7 @@ text! {
             .direction(Direction::Vertical)
             .margin(0)
             .constraints([Constraint::Percentage(50), Constraint::Percentage(50)].as_ref())
-            .split(f.size());
+            .split(f.area());
         (chunks[0], chunks[1])
     };
 
@@ -98,7 +98,7 @@ text! {
     make_block("result", result, result_pane, f);
 }
 
-fn make_block<'a, B: Backend>(title: &str, text: impl Into<Text<'a>>, pos: Rect, f: &mut Frame<B>) {
+fn make_block<'a>(title: &str, text: impl Into<Text<'a>>, pos: Rect, f: &mut Frame) {
     let b = Block::default().title(title).borders(Borders::all());
     let inner = b.inner(pos);
     f.render_widget(b, pos);
@@ -109,7 +109,7 @@ fn make_block<'a, B: Backend>(title: &str, text: impl Into<Text<'a>>, pos: Rect,
 }
 
 fn get_middle(area: Rect) -> Rect {
-    area.inner(&Margin {
+    area.inner(Margin {
         vertical: 2,
         horizontal: 5,
     })

--- a/src/calendar/mod.rs
+++ b/src/calendar/mod.rs
@@ -15,7 +15,7 @@ use ratatui::{
     buffer::Buffer,
     layout::Rect,
     style::Style,
-    text::{Span, Spans},
+    text::{Span, Line},
     widgets::{Block, Widget},
 };
 
@@ -122,7 +122,7 @@ impl<'a, S: DateStyler> Widget for Calendar<'a, S> {
             );
             // cal is 21 cells wide, so hard code the 11
             let x_off = 11_u16.saturating_sub(line.width() as u16 / 2);
-            buf.set_spans(area.x + x_off, area.y, &line.into(), area.width);
+            buf.set_line(area.x + x_off, area.y, &line.into(), area.width);
             area.y += 1
         }
 
@@ -140,19 +140,22 @@ impl<'a, S: DateStyler> Widget for Calendar<'a, S> {
 
         // go through all the weeks containing a day in the target month.
         while curr_day.month() as u8 != self.display_date.month().next() as u8 {
-            let mut line = Spans(Vec::with_capacity(14));
+            let mut line = Line {
+                spans: Vec::with_capacity(14),
+                ..Default::default()
+            };
             for i in 0..7 {
                 // Draw the gutter. Do it here so we can avoid worrying about
                 // styling the ' ' in the format_date method
                 if i == 0 {
-                    line.0.push(Span::styled(" ", Style::default()));
+                    line.push_span(Span::styled(" ", Style::default()));
                 } else {
-                    line.0.push(Span::styled(" ", self.default_bg()));
+                    line.push_span(Span::styled(" ", self.default_bg()));
                 }
-                line.0.push(self.format_date(curr_day));
+                line.push_span(self.format_date(curr_day));
                 curr_day += Duration::DAY;
             }
-            buf.set_spans(area.x, area.y, &line, area.width);
+            buf.set_line(area.x, area.y, &line, area.width);
             area.y += 1;
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
-//! Additional widgets for [tui-rs](https://crates.io/crates/tui).
+//! Additional widgets for [ratatui](https://crates.io/crates/ratatui).
 //!
-//! These widgets are designed to operate similar to the built-in widgets in tui-rs, and should fit
+//! These widgets are designed to operate similar to the built-in widgets in ratatui, and should fit
 //! into your app cleanly.
 //!
 //! TODO: Add example gifs
@@ -9,15 +9,15 @@
 //! By default all the widgets are built and available:
 //! ```toml
 //! [dependencies]
-//! extra-widgets = "0.0.1"
-//! tui = "0.18"
+//! extra-widgets = "0.1.0"
+//! ratatui = "0.28.1"
 //! ```
 //! Alternately, each widget can be enabled individually. The feature names are the same as the
 //! module name for the widget. To just use the calendar widget:
 //! ```toml
 //! [dependencies]
-//! extra-widgets = {"0.0.1" default-features = false, features = ["calendar"] }
-//! tui = "0.18"
+//! extra-widgets = {"0.1.0"" default-features = false, features = ["calendar"] }
+//! ratatui = "0.28.1"
 //! ```
 //! Dependencies for each widget are only pulled if the feature is enabled.
 //!

--- a/src/styled_list/line_iters.rs
+++ b/src/styled_list/line_iters.rs
@@ -1,14 +1,14 @@
 use std::iter::Enumerate;
 
-use ratatui::{style::Style, text::Spans};
+use ratatui::{style::Style, text::Line};
 
 use super::{DisplayLine, LineIndicators, ListItem, Separator};
 
 /// A struct for iterating through display lines given an item and a selection state
 pub(super) struct ToLines<'a> {
     style: Style,
-    text_items: Enumerate<std::vec::IntoIter<Spans<'a>>>,
-    //text_items: VecDeque<(usize, usize, Spans<'a>)>,
+    text_items: Enumerate<std::vec::IntoIter<Line<'a>>>,
+    //text_items: VecDeque<(usize, usize, Line<'a>)>,
     indicators: LineIndicators,
     selected: bool,
     line_count: usize,
@@ -163,7 +163,7 @@ mod test {
         let it = ListItem::new("a\nb\nc").style(style);
 
         for (dl, s) in ToLines::new(it, false).zip(["a", "b", "c"]) {
-            assert_eq!(dl.line, Spans::from(s));
+            assert_eq!(dl.line, Line::from(s));
             assert_eq!(dl.style, style);
         }
     }
@@ -190,7 +190,7 @@ mod test {
             ("d", true),
             ("e", true),
         ]) {
-            assert_eq!(dl.line, Spans::from(t));
+            assert_eq!(dl.line, Line::from(t));
             assert_eq!(dl.must_display, s);
         }
     }
@@ -214,7 +214,7 @@ mod test {
                 (HALF, true, Some(Color::Red), None),
             ])
         {
-            assert_eq!(dl.line, Spans::from(t));
+            assert_eq!(dl.line, Line::from(t));
             assert_eq!(dl.must_display, s);
             assert_eq!(dl.style.bg, bg);
             assert_eq!(dl.style.fg, fg);
@@ -241,7 +241,7 @@ mod test {
                 (HALF, false, None, None),
             ])
         {
-            assert_eq!(dl.line, Spans::from(t));
+            assert_eq!(dl.line, Line::from(t));
             assert_eq!(dl.must_display, s);
             assert_eq!(dl.style.bg, bg);
             assert_eq!(dl.style.fg, fg);
@@ -271,7 +271,7 @@ mod test {
                 (HALF, false, None, None),
             ])
         {
-            assert_eq!(dl.line, Spans::from(t));
+            assert_eq!(dl.line, Line::from(t));
             assert_eq!(dl.must_display, s, "line: {:?}", dl);
             assert_eq!(dl.style.bg, bg);
             assert_eq!(dl.style.fg, fg);
@@ -304,7 +304,7 @@ mod test {
                 (HALF, false, Some(Color::Green), None),
             ])
         {
-            assert_eq!(dl.line, Spans::from(t));
+            assert_eq!(dl.line, Line::from(t));
             assert_eq!(dl.must_display, s, "line: {:?}", dl);
             assert_eq!(dl.style.bg, bg);
             assert_eq!(dl.style.fg, fg);

--- a/src/styled_list/mod.rs
+++ b/src/styled_list/mod.rs
@@ -34,7 +34,7 @@ use ratatui::{
     buffer::Buffer,
     layout::Rect,
     style::Style,
-    text::Spans,
+    text::Line,
     widgets::{Block, StatefulWidget, Widget},
 };
 
@@ -43,14 +43,14 @@ pub use list_state::ListState;
 use separator::Separator;
 
 /// A rendered line of text in the list widget. Multiple DisplayLines can be created from a single
-/// [`ListItem`]. The window operates on an iterable of [`DiplayLine`]s
+/// [`ListItem`]. The window operates on an iterable of [`DisplayLine`]s
 #[derive(Clone, Debug)]
 struct DisplayLine<'a> {
     pub(super) style: Style,
-    pub(super) line: Spans<'a>,
+    pub(super) line: Line<'a>,
     pub(super) must_display: bool,
-    pub(super) left_indicator: Spans<'a>,
-    pub(super) right_indicator: Spans<'a>,
+    pub(super) left_indicator: Line<'a>,
+    pub(super) right_indicator: Line<'a>,
 }
 
 /// Control how lines are rendered
@@ -225,7 +225,7 @@ where
 
             // show the left indicator and adjust the display area for the item text
             if self.show_left_indicator {
-                buf.set_spans(x, y, &l.left_indicator, 1);
+                buf.set_line(x, y, &l.left_indicator, 1);
                 x += 1;
                 line_width -= 1;
             }
@@ -233,11 +233,11 @@ where
             // show the right indicator and adjust the display area for the item text
             if self.show_right_indicator {
                 line_width -= 1;
-                buf.set_spans(x + line_width, y, &l.right_indicator, 1);
+                buf.set_line(x + line_width, y, &l.right_indicator, 1);
             }
 
             // show the item text
-            buf.set_spans(x, y, &l.line, line_width);
+            buf.set_line(x, y, &l.line, line_width);
         }
     }
 }
@@ -258,10 +258,10 @@ impl<'a> DisplayLine<'a> {
     fn filler(x: &'static str) -> Self {
         Self {
             style: Style::default(),
-            line: Spans::from(x),
+            line: Line::from(x),
             must_display: false,
-            left_indicator: Spans::from(x),
-            right_indicator: Spans::from(x),
+            left_indicator: Line::from(x),
+            right_indicator: Line::from(x),
         }
     }
 }

--- a/src/styled_list/window_type.rs
+++ b/src/styled_list/window_type.rs
@@ -201,7 +201,7 @@ where
 mod test {
     use super::*;
     use ratatui::style::Style;
-    use ratatui::text::Spans;
+    use ratatui::text::Line;
 
     #[test]
     fn selection_state_toggle() {
@@ -232,7 +232,7 @@ mod test {
             let must_display = i >= selection_start && i <= selection_end;
             DisplayLine {
                 style: Style::default(),
-                line: Spans::from(s),
+                line: Line::from(s),
                 must_display,
                 left_indicator: " ".into(),
                 right_indicator: " ".into(),
@@ -248,9 +248,9 @@ mod test {
         state.set_pos(0);
         let res: Vec<DisplayLine> = selection_scroll(make_list(1, 1), 3, &mut state).collect();
 
-        assert_eq!(res[0].line.0[0].content, "a");
-        assert_eq!(res[1].line.0[0].content, "b");
-        assert_eq!(res[2].line.0[0].content, "c");
+        assert_eq!(res[0].line.spans[0].content, "a");
+        assert_eq!(res[1].line.spans[0].content, "b");
+        assert_eq!(res[2].line.spans[0].content, "c");
 
         assert!(!res[0].must_display);
         assert!(res[1].must_display);
@@ -265,9 +265,9 @@ mod test {
         state.set_pos(0);
         let res: Vec<DisplayLine> = selection_scroll(make_list(2, 2), 3, &mut state).collect();
 
-        assert_eq!(res[0].line.0[0].content, "a");
-        assert_eq!(res[1].line.0[0].content, "b");
-        assert_eq!(res[2].line.0[0].content, "c");
+        assert_eq!(res[0].line.spans[0].content, "a");
+        assert_eq!(res[1].line.spans[0].content, "b");
+        assert_eq!(res[2].line.spans[0].content, "c");
 
         assert!(!res[0].must_display);
         assert!(!res[1].must_display);
@@ -282,9 +282,9 @@ mod test {
         state.set_pos(0);
         let res: Vec<DisplayLine> = selection_scroll(make_list(3, 4), 3, &mut state).collect();
 
-        assert_eq!(res[0].line.0[0].content, "c");
-        assert_eq!(res[1].line.0[0].content, "d");
-        assert_eq!(res[2].line.0[0].content, "e");
+        assert_eq!(res[0].line.spans[0].content, "c");
+        assert_eq!(res[1].line.spans[0].content, "d");
+        assert_eq!(res[2].line.spans[0].content, "e");
 
         assert!(!res[0].must_display);
         assert!(res[1].must_display);
@@ -299,9 +299,9 @@ mod test {
         state.set_pos(5);
         let res: Vec<DisplayLine> = selection_scroll(make_list(3, 4), 3, &mut state).collect();
 
-        assert_eq!(res[0].line.0[0].content, "d");
-        assert_eq!(res[1].line.0[0].content, "e");
-        assert_eq!(res[2].line.0[0].content, "f");
+        assert_eq!(res[0].line.spans[0].content, "d");
+        assert_eq!(res[1].line.spans[0].content, "e");
+        assert_eq!(res[2].line.spans[0].content, "f");
 
         assert!(res[0].must_display);
         assert!(res[1].must_display);
@@ -316,9 +316,9 @@ mod test {
         state.set_pos(5);
         let res: Vec<DisplayLine> = selection_scroll(make_list(3, 6), 3, &mut state).collect();
 
-        assert_eq!(res[0].line.0[0].content, "d");
-        assert_eq!(res[1].line.0[0].content, "e");
-        assert_eq!(res[2].line.0[0].content, "f");
+        assert_eq!(res[0].line.spans[0].content, "d");
+        assert_eq!(res[1].line.spans[0].content, "e");
+        assert_eq!(res[2].line.spans[0].content, "f");
 
         assert!(res[0].must_display);
         assert!(res[1].must_display);
@@ -333,9 +333,9 @@ mod test {
         state.set_pos(0);
         let res: Vec<DisplayLine> = selection_scroll(make_list(3, 6), 3, &mut state).collect();
 
-        assert_eq!(res[0].line.0[0].content, "d");
-        assert_eq!(res[1].line.0[0].content, "e");
-        assert_eq!(res[2].line.0[0].content, "f");
+        assert_eq!(res[0].line.spans[0].content, "d");
+        assert_eq!(res[1].line.spans[0].content, "e");
+        assert_eq!(res[2].line.spans[0].content, "f");
 
         assert!(res[0].must_display);
         assert!(res[1].must_display);

--- a/src/text_macros/mod.rs
+++ b/src/text_macros/mod.rs
@@ -1,6 +1,6 @@
-//! macros for building and styling text for tui.
+//! Macros for building and styling text for tui.
 
-/// styles text into a span with the bold modifier set. The argument must evaluate to something
+/// Styles text into a span with the bold modifier set. The argument must evaluate to something
 /// that implements [`Into<Span>`](ratatui::text::Span)
 #[macro_export]
 macro_rules! bold {
@@ -11,7 +11,7 @@ macro_rules! bold {
     }};
 }
 
-/// styles text into a span with the italic modifier set. The argument must evaluate to something
+/// Styles text into a span with the italic modifier set. The argument must evaluate to something
 /// that implements [`Into<Span>`](ratatui::text::Span)
 #[macro_export]
 macro_rules! italic {
@@ -22,7 +22,7 @@ macro_rules! italic {
     }};
 }
 
-/// styles text into a span with the underlined modifier set. The argument must evaluate to something
+/// Styles text into a span with the underlined modifier set. The argument must evaluate to something
 /// that implements [`Into<Span>`](ratatui::text::Span)
 #[macro_export]
 macro_rules! underlined {
@@ -33,7 +33,7 @@ macro_rules! underlined {
     }};
 }
 
-/// styles text into a span with the foreground set. The first argument must evaluate to something
+/// Styles text into a span with the foreground set. The first argument must evaluate to something
 /// that implements [`Into<Span>`](ratatui::text::Span), and the second a [`Color`](ratatui::style::Color)
 #[macro_export]
 macro_rules! fg {
@@ -79,45 +79,45 @@ impl<'a> AddLines<::ratatui::text::Span<'a>> for ::ratatui::text::Text<'a> {
     }
 }
 
-impl<'a> AddLines<::ratatui::text::Spans<'a>> for ::ratatui::text::Text<'a> {
-    fn add_lines(&mut self, to_add: ::ratatui::text::Spans<'a>) {
+impl<'a> AddLines<::ratatui::text::Line<'a>> for ::ratatui::text::Text<'a> {
+    fn add_lines(&mut self, to_add: ::ratatui::text::Line<'a>) {
         self.lines.push(to_add);
     }
 }
 
-impl<'a> AddLines<Vec<::ratatui::text::Spans<'a>>> for ::ratatui::text::Text<'a> {
-    fn add_lines(&mut self, mut to_add: Vec<::ratatui::text::Spans<'a>>) {
+impl<'a> AddLines<Vec<::ratatui::text::Line<'a>>> for ::ratatui::text::Text<'a> {
+    fn add_lines(&mut self, mut to_add: Vec<::ratatui::text::Line<'a>>) {
         self.lines.append(&mut to_add);
     }
 }
 
-/// Create a [`Vec<Spans>`](ratatui::text::Spans) from lines of a string separated by '\n'
+/// Create a [`Vec<Line>`](ratatui::text::Line) from lines of a string separated by '\n'
 #[macro_export]
 macro_rules! split {
     ($e:expr) => {{
         $e.lines()
-            .map(|l| ::ratatui::text::Spans::from(l))
-            .collect::<Vec<::ratatui::text::Spans>>()
+            .map(|l| ::ratatui::text::Line::from(l))
+            .collect::<Vec<::ratatui::text::Line>>()
     }};
 }
 
-/// Create a single [Spans](ratatui::text::Spans) from many
+/// Create a single [Line](ratatui::text::Line) from many
 /// [Span](ratatui::text::Span) structs. Useful with [`text!`](crate::text!)
 /// for having multiple stylings in a single line
 #[macro_export]
 macro_rules! line {
     ($($e:expr),* $(,)?) => {{
-        let mut res = ::ratatui::text::Spans::default();
-        $(res.0.push(::ratatui::text::Span::from($e));)*;
+        let mut res = ::ratatui::text::Line::default();
+        $(res.push_span(::ratatui::text::Span::from($e));)*;
         res
     }};
 }
 
-/// Creates a `Vec<Spans>` from each line of the enclosed block
+/// Creates a [`Vec<Line>`](ratatui::text::Line) from each line of the enclosed block
 #[macro_export]
 macro_rules! text {
     ($t:expr) => {
-        res.push(Spans::from($t));
+        res.push(Line::from($t));
     };
     ($($t:expr);* $(;)?) => {{
         use $crate::text_macros::AddLines;
@@ -131,7 +131,7 @@ macro_rules! text {
 mod tests {
     use ratatui::{
         style::{Modifier, Style},
-        text::{Span, Spans, Text},
+        text::{Span, Line, Text},
     };
 
     #[test]
@@ -170,15 +170,15 @@ mod tests {
     #[test]
     fn text() {
         let mut expected = Text::from(vec![
-            Spans::from(Span::styled(
+            Line::from(Span::styled(
                 "foo",
                 Style::default().add_modifier(Modifier::ITALIC),
             )),
-            Spans::from(Span::styled(
+            Line::from(Span::styled(
                 "bar",
                 Style::default().add_modifier(Modifier::UNDERLINED),
             )),
-            Spans::from("baz"),
+            Line::from("baz"),
         ]);
 
         let test = text! {
@@ -202,15 +202,15 @@ mod tests {
             "a\nb";
             split!("q\nr")
         };
-        expected.lines.push(Spans::from("a\nb"));
-        expected.lines.push(Spans::from("q"));
-        expected.lines.push(Spans::from("r"));
+        expected.lines.push(Line::from("a\nb"));
+        expected.lines.push(Line::from("q"));
+        expected.lines.push(Line::from("r"));
         assert_eq!(expected, test);
     }
 
     #[test]
     fn text_single_line() {
-        let expected = Text::from(vec![Spans::from(Span::styled(
+        let expected = Text::from(vec![Line::from(Span::styled(
             "foo",
             Style::default().add_modifier(Modifier::ITALIC),
         ))]);


### PR DESCRIPTION
This repo hasn't been updated in a long time and I wanted to use it in one of my own projects. It also doesn't seem like this is getting merged into another project anytime soon, ratatui/ratatui#118 is tagged as "Status: On Hold", and in preiter93/tui-widget-list#20 the project owner mentioned not having enough time.
So I took it upon myself to update this project to keep it maintained until something happens with it.
 
I'll leave it up to you, but you may want to bump the package version in Cargo.toml since this is a pretty big update.

## Changes
- Bumped `ratatui` to 0.28.1, `crossterm` to 0.28.1, lazy_static to `1.5.0`, and time to `0.3.36`.
- ratatui's `Frame` is no longer generic over the backend, and `.size()` was deprecated and replaced with `.area()`. 
- `ratatui::text::Spans` was renamed to `Line`, and is no longer a tuple struct.
- Fixed a bug in the list demo example on Windows where keys would double press.
- Updated documentation to use the correct versions of packages, and the correct names (there were a few leftover references to tui-rs)
- Fixed capitalization and broken links in some of the docs
- A few other minor changes.